### PR TITLE
Add record function tag definition

### DIFF
--- a/draft-ietf-cbor-packed.md
+++ b/draft-ietf-cbor-packed.md
@@ -668,9 +668,11 @@ whose items are treated as value items for the resulting map.
 The map is constructed by grouping key and value items
 with equal position in the provided arrays into pairs that constitute the resulting map.
 
-If the matching value item for a given key item is either >undefined< (simple value 23)
-or does not exist (because the value item array is shorter than the key item array),
-the resulting pair is not included in the resulting map.
+The value item array MAY be shorter than the key item array, in which
+case the one or more unmatched value items towards the end are treated as _absent_.
+Additionally, value items that are the CBOR simple value `undefined`
+(simple(23), encoding 0xf7) are also treated as absent.
+Key items whose matching value items are absent are not included in the resulting map.
 
 For an example, we assume this unpacked data item:
 

--- a/draft-ietf-cbor-packed.md
+++ b/draft-ietf-cbor-packed.md
@@ -943,9 +943,9 @@ so it uses the simple common-table setup form (tag 113).
               "Moby Dick", simple(3), "0-553-21311-3"]),
            6([simple(2), "J. R. R. Tolkien",
                "The Lord of the Rings", 22.99, "0-395-19395-8"])],
-       "bicycle": {"color": "red", simple(0): 19.95}}}])
+       "bicycle": {"color": "red", simple(1): 19.95}}}])
 ~~~
-{: #fig-example-out-record title="Example packed CBOR data item with item and argument sharing"}
+{: #fig-example-out-record title="Example packed CBOR data item using item sharing and the record function tag"}
 
 
 The (JSON-compatible) CBOR data structure below has been packed with shared


### PR DESCRIPTION
As discussed [on the mailing list](https://mailarchive.ietf.org/arch/msg/cbor/-sgR9-RrgXlAY9LZj8mzk-6fDKU/) and the [last interim](https://datatracker.ietf.org/doc/minutes-interim-2024-cbor-04-202402211500/).

I've also added example usage of the record function as an alternative for the first example. The second example would probably also benefit from it, but it might also make the example even harder to understand?