### PR TITLE
Use `undefined` to remove map entries during concatenation

### DIFF
--- a/draft-ietf-cbor-packed.md
+++ b/draft-ietf-cbor-packed.md
@@ -405,14 +405,22 @@ The concatenation function is defined as follows:
   left-hand-side map, and then filled in with the members of the
   right-hand side map, replacing any existing members that have the
   same key.
+  In order to be able to remove a map entry from the left-hand-side
+  map, as a special case, any members to be replaced with a value of
+  `undefined` (0xf7) from the right-hand-side map are instead removed,
+  and right-hand-side members with the value `undefined` are never
+  filled in into the concatenated map.
 
 {:aside}
-> NOTE:
-  One application of the rule for straight references is to supply
+> NOTES:
+>
+> * One application of the rule for straight references is to supply
   default values out of a dictionary, which can then be overridden by
   the entries in the map supplied as the rump data item.
-  Note that this pattern provides no way to remove a map entry from
-  the prefix table entry.
+> * Special casing the member value `undefined` makes it impossible to
+  use this construct for updating maps by insertion of or
+  replacement with actual `undefined` member values; `undefined` as a
+  member value on the left-hand-side map stays untouched though.
 
 * If both left-hand side and right-hand side are one of the string
   types (not necessarily the same), the bytes of the left-hand side

--- a/draft-ietf-cbor-packed.md
+++ b/draft-ietf-cbor-packed.md
@@ -50,6 +50,7 @@ informative:
   STD63: utf8
 #    =: RFC3629
   RFC7049: orig
+  RFC7396: merge
   RFC8742: seq
   RFC6920: ni
   RFC1951: deflate
@@ -421,6 +422,9 @@ The concatenation function is defined as follows:
   use this construct for updating maps by insertion of or
   replacement with actual `undefined` member values; `undefined` as a
   member value on the left-hand-side map stays untouched though.
+  This exception is similar to the one JSON Merge Patch {{-merge}} makes
+  for `null` values, which are however much more commonly used and
+  therefore more problematic.
 
 * If both left-hand side and right-hand side are one of the string
   types (not necessarily the same), the bytes of the left-hand side


### PR DESCRIPTION
This is text that could be used to have member values of `undefined` in RHS maps during concatenation remove members instead.

I'm not yet sure this additional wart is worth the complexity, but with tag 114 ("r") already special-casing `undefined` in a similar way, this becomes less of an additional pain.
