### PR TITLE
Editorial improvements and some clarifications

### DIFF
--- a/draft-ietf-cbor-packed.md
+++ b/draft-ietf-cbor-packed.md
@@ -106,7 +106,8 @@ informative:
 [^status]:
     (This cref will be removed by the RFC editor:)\\
     The present revision -17 contains a number of editorial
-    improvements, it is intended foro brief discussion at the 2025-10-15 CBOR WG interim.
+    improvements, it is intended for a brief discussion at the
+    2025-10-15 CBOR WG interim.
     The wording of the present revision continues to make use of
     the tunables A/B/C to be set to specific numbers before completing
     the Packed CBOR specification; not all the examples may fully


### PR DESCRIPTION
Mostly clarifying the interplay between non-packed stand-in items and nested packed CBOR in argument references, as discussed offline at the IETF hackathon.

Apart from that:
- unifying the tables defining reference items with tag 6 (cc @miri64 who was also confused about the differing syntax)
- clarifying that media-type supplied tables are only an _example_ of application-dependent initial tables
- fixing two typos